### PR TITLE
feat: keep auto-login session state separate from interactive login

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -313,7 +313,7 @@ module.exports = (issuer, aadIssValidation = false) => class Client extends Base
    * @name callbackParams
    * @api public
    */
-  callbackParams(input) { // eslint-disable-line class-methods-use-this
+  callbackParams(input, paramList = CALLBACK_PROPERTIES) { // eslint-disable-line class-methods-use-this
     const isIncomingMessage = input instanceof stdhttp.IncomingMessage
       || (input && input.method && input.url);
     const isString = typeof input === 'string';
@@ -354,7 +354,7 @@ module.exports = (issuer, aadIssValidation = false) => class Client extends Base
       uri = input;
     }
 
-    return _.pick(url.parse(uri, true).query, CALLBACK_PROPERTIES);
+    return _.pick(url.parse(uri, true).query, paramList);
   }
 
   /**

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -75,13 +75,20 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
       throw new Error('authentication requires session support when using state, max_age or nonce');
     }
     const reqParams = client.callbackParams(req);
-    const sessionKey = this._key;
+
+    const isAutoLogin = getIsAutoLogin(client.callbackParams(req, ['state', 'invisible']));
+    const sessionKey = isAutoLogin ?
+        `${this._key}-auto` :
+        this._key;
 
     /* start authentication request */
     if (_.isEmpty(reqParams)) {
       // provide options object with extra authentication parameters
+      const randomState = random();
       const params = _.defaults({}, options, this._params, {
-        state: random(),
+        state: isAutoLogin ?
+            `${randomState}|auto` :
+            randomState
       });
 
       if (!params.nonce && params.response_type.includes('id_token')) {
@@ -192,5 +199,27 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
     this.error(err);
   }
 };
+
+/**
+ * In a vain attempt to stop auto-login from overwritting our interactive login
+ * SSO flow, we should try to stash it separately.
+ * This function knows it is a "auto-login" flow if ?invisible=truthy is in the query
+ * or the state param is postfixed with |auto
+ * @param {string} state
+ * @param {string} invisible
+ * @returns {boolean} - is auto login
+ */
+function getIsAutoLogin({ state, invisible }) {
+    if (invisible) {
+        return true;
+    }
+    if (state) {
+        const [stateVal, isAuto] = state.split('|');
+        if (isAuto) {
+            return true;
+        }
+    }
+    return false;
+}
 
 module.exports = OpenIDConnectStrategy;

--- a/test/issuer/default_http_options.test.js
+++ b/test/issuer/default_http_options.test.js
@@ -9,7 +9,7 @@ describe('Issuer#defaultHttpOptions', function () {
 
   it('includes a user-agent by default', function () {
     expect(Issuer.defaultHttpOptions).to.have.nested.property('headers.User-Agent')
-      .to.match(/^openid-client/);
+      .to.match(/openid-client/);
   });
 
   it('does not retry', function () {
@@ -38,7 +38,7 @@ describe('Issuer#defaultHttpOptions=', function () {
   it('can be set to send more headers by default', function () {
     Issuer.defaultHttpOptions = { headers: { 'X-Meta-Id': 'meta meta' } };
     expect(Issuer.defaultHttpOptions).to.have.nested.property('headers.User-Agent')
-      .to.match(/^openid-client/);
+      .to.match(/openid-client/);
     expect(Issuer.defaultHttpOptions).to.have.nested.property('headers.X-Meta-Id', 'meta meta');
   });
 


### PR DESCRIPTION
Things are getting messy. Any suggestions welcome!

 - If login url has `?invisible=truthy` within it then the sessionKey becomes `oidc:login.vixen.com-auto`
 - if the url has `?state=<random>|auto` in it then the sessionKey becomes `oidc:login.vixen.com-auto`